### PR TITLE
Updated CMakeLists.txt to use the current source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ add_definitions( -DUNORDERED )
 
 include_directories( BEFORE LASzip/src LASlib/inc  )
 
-file( GLOB LASLIB_SOURCES "${CMAKE_SOURCE_DIR}/LASlib/src/*.cpp")
-file( GLOB LASZIP_SOURCES "${CMAKE_SOURCE_DIR}/LASzip/src/*.cpp")
+file( GLOB LASLIB_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/LASlib/src/*.cpp")
+file( GLOB LASZIP_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/LASzip/src/*.cpp")
 
 add_library( las SHARED ${LASLIB_SOURCES} ${LASZIP_SOURCES} )
 


### PR DESCRIPTION
Using the CMAKE_SOURCE_DIR causes failures when attempting to integrate into packageing systems like conan.